### PR TITLE
Removed duplicate home page URL key

### DIFF
--- a/snippets/skinobjects.cson
+++ b/snippets/skinobjects.cson
@@ -49,11 +49,6 @@
     'description': 'Portal Description'
     'body': '<% =PortalSettings.ActiveTab.Description %>'
 
-  'DNN Skin Token: Home Page URL':
-    'prefix': 'dnnhomepageurl'
-    'description': 'ome Page URL'
-    'body': '<%= DotNetNuke.Common.Globals.NavigateURL(PortalSettings.HomeTabId) %>'
-
   'DNN Skin Token: Container Pane':
     'prefix': 'dnnpane'
     'description': 'Container Pane'


### PR DESCRIPTION
'DNN Skin Token: Home Page URL' key was duplicated, causing an error when starting Atom. The first entry has been removed, fixing the error.